### PR TITLE
fix: new list format

### DIFF
--- a/internal/zmx/session_test.go
+++ b/internal/zmx/session_test.go
@@ -183,6 +183,30 @@ func TestFetchSessionsNewFormat(t *testing.T) {
 	}
 }
 
+func TestFetchSessionsNewFormatCurrentSession(t *testing.T) {
+	orig := deps
+	defer func() { deps = orig }()
+
+	deps.command = func(name string, arg ...string) *exec.Cmd {
+		script := "printf '→ name=current\\tpid=456\\tclients=1\\tcreated=1774179340\\tstart_dir=/Users/example/current\\n'"
+		return exec.Command("sh", "-c", script)
+	}
+
+	got, err := FetchSessions()
+	if err != nil {
+		t.Fatalf("FetchSessions error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(got))
+	}
+	if got[0].Name != "current" {
+		t.Errorf("Name = %q, want %q", got[0].Name, "current")
+	}
+	if got[0].StartedIn != "/Users/example/current" {
+		t.Errorf("StartedIn = %q, want %q", got[0].StartedIn, "/Users/example/current")
+	}
+}
+
 func TestFetchSessionsOldFormat(t *testing.T) {
 	orig := deps
 	defer func() { deps = orig }()

--- a/internal/zmx/session_test.go
+++ b/internal/zmx/session_test.go
@@ -152,7 +152,38 @@ func TestTailLinesFromReader_AtLeastOneLine(t *testing.T) {
 	}
 }
 
-func TestFetchSessionsWithInjectedDeps(t *testing.T) {
+func TestFetchSessionsNewFormat(t *testing.T) {
+	orig := deps
+	defer func() { deps = orig }()
+
+	deps.command = func(name string, arg ...string) *exec.Cmd {
+		script := "printf 'name=demo\\tpid=123\\tclients=0\\tcreated=1774179340\\tstart_dir=/Users/example/derp\\n'"
+		return exec.Command("sh", "-c", script)
+	}
+
+	got, err := FetchSessions()
+	if err != nil {
+		t.Fatalf("FetchSessions error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(got))
+	}
+	s := got[0]
+	if s.Name != "demo" {
+		t.Errorf("Name = %q, want %q", s.Name, "demo")
+	}
+	if s.PID != "123" {
+		t.Errorf("PID = %q, want %q", s.PID, "123")
+	}
+	if s.Clients != 0 {
+		t.Errorf("Clients = %d, want 0", s.Clients)
+	}
+	if s.StartedIn != "/Users/example/derp" {
+		t.Errorf("StartedIn = %q, want %q", s.StartedIn, "/Users/example/derp")
+	}
+}
+
+func TestFetchSessionsOldFormat(t *testing.T) {
 	orig := deps
 	defer func() { deps = orig }()
 
@@ -165,8 +196,24 @@ func TestFetchSessionsWithInjectedDeps(t *testing.T) {
 	if err != nil {
 		t.Fatalf("FetchSessions error: %v", err)
 	}
-	if len(got) != 1 || got[0].Name != "demo" || got[0].PID != "123" || got[0].Clients != 2 {
-		t.Fatalf("unexpected sessions parsed: %+v", got)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(got))
+	}
+	s := got[0]
+	if s.Name != "demo" {
+		t.Errorf("Name = %q, want %q", s.Name, "demo")
+	}
+	if s.PID != "123" {
+		t.Errorf("PID = %q, want %q", s.PID, "123")
+	}
+	if s.Clients != 2 {
+		t.Errorf("Clients = %d, want 2", s.Clients)
+	}
+	if s.StartedIn != "/tmp" {
+		t.Errorf("StartedIn = %q, want %q", s.StartedIn, "/tmp")
+	}
+	if s.Cmd != "vim" {
+		t.Errorf("Cmd = %q, want %q", s.Cmd, "vim")
 	}
 }
 

--- a/internal/zmx/sessions.go
+++ b/internal/zmx/sessions.go
@@ -48,7 +48,7 @@ func FetchSessions() ([]Session, error) {
 				continue
 			}
 			switch k {
-			case "session_name":
+			case "session_name", "name":
 				s.Name = v
 			case "pid":
 				s.PID = v
@@ -62,7 +62,7 @@ func FetchSessions() ([]Session, error) {
 					}
 					s.Clients = n
 				}
-			case "started_in":
+			case "started_in", "start_dir":
 				s.StartedIn = v
 			case "cmd":
 				s.Cmd = v

--- a/internal/zmx/sessions.go
+++ b/internal/zmx/sessions.go
@@ -37,6 +37,7 @@ func FetchSessions() ([]Session, error) {
 	var sessions []Session
 	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
 		line = strings.TrimSpace(line)
+		line = strings.TrimSpace(strings.TrimPrefix(line, "→"))
 		if line == "" {
 			continue
 		}


### PR DESCRIPTION
`zmx` 0.4.2 changed the format of `zmx list` output which broke `zms`.
Added the new `name` and `start_dir` parameters to the parser so that
`zms` stays backwards compatible with the old versions.

Fixes #6.