### PR TITLE
fix: handle zmx 0.4.2 field name changes in list output

### DIFF
--- a/internal/zmx/session_test.go
+++ b/internal/zmx/session_test.go
@@ -170,6 +170,39 @@ func TestFetchSessionsWithInjectedDeps(t *testing.T) {
 	}
 }
 
+func TestFetchSessionsNewFormat(t *testing.T) {
+	orig := deps
+	defer func() { deps = orig }()
+
+	deps.command = func(name string, arg ...string) *exec.Cmd {
+		script := "printf 'name=cosmic-repl\tpid=24210\tclients=1\tcreated=1774349729\tstart_dir=/home/user/dev\tcmd=bb dev\n'"
+		return exec.Command("sh", "-c", script)
+	}
+
+	got, err := FetchSessions()
+	if err != nil {
+		t.Fatalf("FetchSessions error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 session, got %d: %+v", len(got), got)
+	}
+	if got[0].Name != "cosmic-repl" {
+		t.Errorf("Name = %q, want %q", got[0].Name, "cosmic-repl")
+	}
+	if got[0].PID != "24210" {
+		t.Errorf("PID = %q, want %q", got[0].PID, "24210")
+	}
+	if got[0].Clients != 1 {
+		t.Errorf("Clients = %d, want 1", got[0].Clients)
+	}
+	if got[0].StartedIn != "/home/user/dev" {
+		t.Errorf("StartedIn = %q, want %q", got[0].StartedIn, "/home/user/dev")
+	}
+	if got[0].Cmd != "bb dev" {
+		t.Errorf("Cmd = %q, want %q", got[0].Cmd, "bb dev")
+	}
+}
+
 func TestCopyToClipboardUsesInjectedDeps(t *testing.T) {
 	orig := deps
 	defer func() { deps = orig }()

--- a/internal/zmx/sessions.go
+++ b/internal/zmx/sessions.go
@@ -48,7 +48,7 @@ func FetchSessions() ([]Session, error) {
 				continue
 			}
 			switch k {
-			case "session_name":
+			case "session_name", "name":
 				s.Name = v
 			case "pid":
 				s.PID = v
@@ -62,7 +62,7 @@ func FetchSessions() ([]Session, error) {
 					}
 					s.Clients = n
 				}
-			case "started_in":
+			case "started_in", "start_dir":
 				s.StartedIn = v
 			case "cmd":
 				s.Cmd = v


### PR DESCRIPTION
zmx 0.4.2 renamed 'session_name' to 'name' and 'started_in' to 'start_dir' in its list output. Accept both old and new key names so zsm works across zmx versions.