### PR TITLE
fix zmx list parsing

### DIFF
--- a/internal/zmx/session_test.go
+++ b/internal/zmx/session_test.go
@@ -157,7 +157,7 @@ func TestFetchSessionsWithInjectedDeps(t *testing.T) {
 	defer func() { deps = orig }()
 
 	deps.command = func(name string, arg ...string) *exec.Cmd {
-		script := "printf 'session_name=demo\\tpid=123\\tclients=2\\tstarted_in=/tmp\\tcmd=vim\\n'"
+		script := "printf 'name=demo\\tpid=123\\tclients=2\\tstart_dir=/tmp\\tcmd=vim\\n'"
 		return exec.Command("sh", "-c", script)
 	}
 

--- a/internal/zmx/sessions.go
+++ b/internal/zmx/sessions.go
@@ -42,13 +42,14 @@ func FetchSessions() ([]Session, error) {
 		}
 
 		s := Session{}
+		line = strings.TrimLeft(line, "→ ")
 		for _, field := range strings.Split(line, "\t") {
 			k, v, ok := strings.Cut(field, "=")
 			if !ok {
 				continue
 			}
 			switch k {
-			case "session_name":
+			case "name":
 				s.Name = v
 			case "pid":
 				s.PID = v
@@ -62,7 +63,7 @@ func FetchSessions() ([]Session, error) {
 					}
 					s.Clients = n
 				}
-			case "started_in":
+			case "start_dir":
 				s.StartedIn = v
 			case "cmd":
 				s.Cmd = v


### PR DESCRIPTION
these must have changed after zsm was developed

session_name => name
started_in => start_dir

fixes: #6
