### PR TITLE
return to zsm after detaching from session

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ go install github.com/mdsakalu/zmx-session-manager@latest
 | `↑` `↓` | Navigate sessions |
 | `space` | Toggle selection |
 | `ctrl+a` | Select / deselect all |
-| `enter` | Attach to session |
+| `enter` | Attach to session, then return to zsm after detaching |
+| `e` | Attach by replacing zsm (legacy behavior) |
 | `k` | Kill selected session(s) |
 | `c` | Copy attach command |
 | `s` | Cycle sort mode (name / clients / newest) |

--- a/internal/tui/model_core.go
+++ b/internal/tui/model_core.go
@@ -38,6 +38,21 @@ const (
 	sortModeCount
 )
 
+// AttachMode describes how zsm should launch the selected zmx session.
+type AttachMode uint8
+
+const (
+	AttachNone AttachMode = iota
+	AttachAndReturn
+	AttachReplaceProcess
+)
+
+// AttachRequest is the action selected when the TUI exits.
+type AttachRequest struct {
+	Target string
+	Mode   AttachMode
+}
+
 func (s sortMode) label() string {
 	switch s {
 	case sortByName:
@@ -149,11 +164,10 @@ type Model struct {
 	listOffset int
 	selected   map[string]bool
 
-	filterText   string
-	sortMode     sortMode
-	sortAsc      bool
-	attachTarget string // non-empty → attach to this session
-	attachReplace bool   // true → syscall.Exec (replace), false → exec.Command (loop)
+	filterText string
+	sortMode   sortMode
+	sortAsc    bool
+	attach     AttachRequest
 
 	preview        string
 	previewScrollX int
@@ -201,8 +215,8 @@ func NewModel() Model {
 	return initialModel()
 }
 
-func (m Model) AttachTarget() (string, bool) {
-	return m.attachTarget, m.attachReplace
+func (m Model) AttachRequest() AttachRequest {
+	return m.attach
 }
 
 // visibleSessions returns sessions matching the current filter, sorted by sortMode.

--- a/internal/tui/model_core.go
+++ b/internal/tui/model_core.go
@@ -152,7 +152,8 @@ type Model struct {
 	filterText   string
 	sortMode     sortMode
 	sortAsc      bool
-	attachTarget string // non-empty → exec zmx attach after quit
+	attachTarget string // non-empty → attach to this session
+	attachReplace bool   // true → syscall.Exec (replace), false → exec.Command (loop)
 
 	preview        string
 	previewScrollX int
@@ -200,8 +201,8 @@ func NewModel() Model {
 	return initialModel()
 }
 
-func (m Model) AttachTarget() string {
-	return m.attachTarget
+func (m Model) AttachTarget() (string, bool) {
+	return m.attachTarget, m.attachReplace
 }
 
 // visibleSessions returns sessions matching the current filter, sorted by sortMode.

--- a/internal/tui/model_input.go
+++ b/internal/tui/model_input.go
@@ -85,8 +85,7 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 
 	case tea.KeyEnter:
 		if m.cursor < len(visible) {
-			m.attachTarget = visible[m.cursor].Name
-			m.attachReplace = false // Loop back after detach
+			m.attach = AttachRequest{Target: visible[m.cursor].Name, Mode: AttachAndReturn}
 			return m, tea.Quit
 		}
 
@@ -95,8 +94,7 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			switch msg.Text {
 			case "e":
 				if m.cursor < len(visible) {
-					m.attachTarget = visible[m.cursor].Name
-					m.attachReplace = true // Replace process
+					m.attach = AttachRequest{Target: visible[m.cursor].Name, Mode: AttachReplaceProcess}
 					return m, tea.Quit
 				}
 			case "k":

--- a/internal/tui/model_input.go
+++ b/internal/tui/model_input.go
@@ -86,12 +86,19 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	case tea.KeyEnter:
 		if m.cursor < len(visible) {
 			m.attachTarget = visible[m.cursor].Name
+			m.attachReplace = false // Loop back after detach
 			return m, tea.Quit
 		}
 
 	default:
 		if msg.Text != "" {
 			switch msg.Text {
+			case "e":
+				if m.cursor < len(visible) {
+					m.attachTarget = visible[m.cursor].Name
+					m.attachReplace = true // Replace process
+					return m, tea.Quit
+				}
 			case "k":
 				targets := m.killTargets()
 				if len(targets) > 0 {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -167,6 +167,39 @@ func TestVisibleSessionsInvalidatesAfterFilterAndSortChange(t *testing.T) {
 	}
 }
 
+func TestAttachKeysProduceExplicitRequests(t *testing.T) {
+	tests := []struct {
+		name string
+		key  tea.KeyPressMsg
+		want AttachRequest
+	}{
+		{
+			name: "enter returns to zsm after detach",
+			key:  tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}),
+			want: AttachRequest{Target: "demo", Mode: AttachAndReturn},
+		},
+		{
+			name: "e replaces zsm process",
+			key:  tea.KeyPressMsg(tea.Key{Code: 'e', Text: "e"}),
+			want: AttachRequest{Target: "demo", Mode: AttachReplaceProcess},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := initialModel()
+			m.sessions = []Session{{Name: "demo"}}
+			m.markSessionsChanged()
+
+			updated, _ := m.Update(tt.key)
+			got := updated.(Model).AttachRequest()
+			if got != tt.want {
+				t.Fatalf("AttachRequest() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
 // stripStyleCodes removes ANSI escape sequences for test comparison.
 func stripStyleCodes(s string) string {
 	re := regexp.MustCompile(`\x1b\[[0-9;]*m`)

--- a/internal/tui/model_view.go
+++ b/internal/tui/model_view.go
@@ -294,6 +294,7 @@ func (m Model) renderHelp() string {
 		helpKeyStyle.Render("space") + helpStyle.Render(" sel"),
 		helpKeyStyle.Render("^a") + helpStyle.Render(" all"),
 		helpKeyStyle.Render("enter") + helpStyle.Render(" attach"),
+		helpKeyStyle.Render("e") + helpStyle.Render(" exec"),
 		helpKeyStyle.Render("k") + helpStyle.Render(" kill"),
 		helpKeyStyle.Render("c") + helpStyle.Render(" copy cmd"),
 		helpKeyStyle.Render("s") + helpStyle.Render(" sort"),

--- a/main.go
+++ b/main.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"syscall"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/mdsakalu/zmx-session-manager/internal/tui"
@@ -28,16 +27,32 @@ func main() {
 		os.Exit(1)
 	}
 
-	p := tea.NewProgram(tui.NewModel())
-	finalModel, err := p.Run()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		os.Exit(1)
-	}
+	for {
+		p := tea.NewProgram(tui.NewModel())
+		finalModel, err := p.Run()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
 
-	// If the user pressed Enter to attach, exec into zmx attach
-	if m, ok := finalModel.(tui.Model); ok && m.AttachTarget() != "" {
-		env := os.Environ()
-		syscall.Exec(zmxPath, []string{"zmx", "attach", m.AttachTarget()}, env)
+		// If the user pressed Enter to attach, run zmx attach and then loop back
+		if m, ok := finalModel.(tui.Model); ok && m.AttachTarget() != "" {
+			cmd := exec.Command(zmxPath, "attach", m.AttachTarget())
+			cmd.Stdin = os.Stdin
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+
+			if err := cmd.Run(); err != nil {
+				fmt.Fprintf(os.Stderr, "Error: failed to attach to session %q: %v\n", m.AttachTarget(), err)
+				// Wait for user to read the error before returning to zsm
+				fmt.Print("Press Enter to return to zsm...")
+				var dummy string
+				fmt.Scanln(&dummy)
+			}
+			continue
+		}
+
+		// Otherwise, the user quit the TUI normally
+		break
 	}
 }

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"syscall"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/mdsakalu/zmx-session-manager/internal/tui"
@@ -35,21 +36,32 @@ func main() {
 			os.Exit(1)
 		}
 
-		// If the user pressed Enter to attach, run zmx attach and then loop back
-		if m, ok := finalModel.(tui.Model); ok && m.AttachTarget() != "" {
-			cmd := exec.Command(zmxPath, "attach", m.AttachTarget())
-			cmd.Stdin = os.Stdin
-			cmd.Stdout = os.Stdout
-			cmd.Stderr = os.Stderr
+		// If the user pressed a key to attach, run zmx attach
+		if m, ok := finalModel.(tui.Model); ok {
+			target, replace := m.AttachTarget()
+			if target != "" {
+				if replace {
+					env := os.Environ()
+					syscall.Exec(zmxPath, []string{"zmx", "attach", target}, env)
+					// If syscall.Exec fails, we might still be here
+					fmt.Fprintf(os.Stderr, "Error: failed to exec into session %q\n", target)
+					os.Exit(1)
+				}
 
-			if err := cmd.Run(); err != nil {
-				fmt.Fprintf(os.Stderr, "Error: failed to attach to session %q: %v\n", m.AttachTarget(), err)
-				// Wait for user to read the error before returning to zsm
-				fmt.Print("Press Enter to return to zsm...")
-				var dummy string
-				fmt.Scanln(&dummy)
+				cmd := exec.Command(zmxPath, "attach", target)
+				cmd.Stdin = os.Stdin
+				cmd.Stdout = os.Stdout
+				cmd.Stderr = os.Stderr
+
+				if err := cmd.Run(); err != nil {
+					fmt.Fprintf(os.Stderr, "Error: failed to attach to session %q: %v\n", target, err)
+					// Wait for user to read the error before returning to zsm
+					fmt.Print("Press Enter to return to zsm...")
+					var dummy string
+					fmt.Scanln(&dummy)
+				}
+				continue
 			}
-			continue
 		}
 
 		// Otherwise, the user quit the TUI normally

--- a/main.go
+++ b/main.go
@@ -28,43 +28,65 @@ func main() {
 		os.Exit(1)
 	}
 
+	err = runSessionManager(runTUI, func(request tui.AttachRequest) error {
+		return attachToSession(zmxPath, request)
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func runSessionManager(
+	runUI func() (tui.AttachRequest, error),
+	attach func(tui.AttachRequest) error,
+) error {
 	for {
-		p := tea.NewProgram(tui.NewModel())
-		finalModel, err := p.Run()
+		request, err := runUI()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			os.Exit(1)
+			return fmt.Errorf("run TUI: %w", err)
 		}
-
-		// If the user pressed a key to attach, run zmx attach
-		if m, ok := finalModel.(tui.Model); ok {
-			target, replace := m.AttachTarget()
-			if target != "" {
-				if replace {
-					env := os.Environ()
-					syscall.Exec(zmxPath, []string{"zmx", "attach", target}, env)
-					// If syscall.Exec fails, we might still be here
-					fmt.Fprintf(os.Stderr, "Error: failed to exec into session %q\n", target)
-					os.Exit(1)
-				}
-
-				cmd := exec.Command(zmxPath, "attach", target)
-				cmd.Stdin = os.Stdin
-				cmd.Stdout = os.Stdout
-				cmd.Stderr = os.Stderr
-
-				if err := cmd.Run(); err != nil {
-					fmt.Fprintf(os.Stderr, "Error: failed to attach to session %q: %v\n", target, err)
-					// Wait for user to read the error before returning to zsm
-					fmt.Print("Press Enter to return to zsm...")
-					var dummy string
-					fmt.Scanln(&dummy)
-				}
-				continue
-			}
+		if request.Target == "" || request.Mode == tui.AttachNone {
+			return nil
 		}
+		if err := attach(request); err != nil {
+			return fmt.Errorf("attach to session %q: %w", request.Target, err)
+		}
+		if request.Mode == tui.AttachReplaceProcess {
+			return fmt.Errorf("replace attach for session %q returned unexpectedly", request.Target)
+		}
+	}
+}
 
-		// Otherwise, the user quit the TUI normally
-		break
+func runTUI() (tui.AttachRequest, error) {
+	finalModel, err := tea.NewProgram(tui.NewModel()).Run()
+	if err != nil {
+		return tui.AttachRequest{}, err
+	}
+	m, ok := finalModel.(tui.Model)
+	if !ok {
+		return tui.AttachRequest{}, nil
+	}
+	return m.AttachRequest(), nil
+}
+
+func attachToSession(zmxPath string, request tui.AttachRequest) error {
+	switch request.Mode {
+	case tui.AttachAndReturn:
+		cmd := exec.Command(zmxPath, "attach", request.Target)
+		cmd.Stdin = os.Stdin
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: failed to attach to session %q: %v\n", request.Target, err)
+			fmt.Print("Press Enter to return to zsm...")
+			var input string
+			fmt.Scanln(&input)
+		}
+		return nil
+	case tui.AttachReplaceProcess:
+		return syscall.Exec(zmxPath, []string{"zmx", "attach", request.Target}, os.Environ())
+	default:
+		return fmt.Errorf("unsupported attach mode %d", request.Mode)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/mdsakalu/zmx-session-manager/internal/tui"
+)
+
+func TestRunSessionManagerReturnsToUIAfterDetach(t *testing.T) {
+	requests := []tui.AttachRequest{
+		{Target: "demo", Mode: tui.AttachAndReturn},
+		{},
+	}
+	uiCalls := 0
+	runUI := func() (tui.AttachRequest, error) {
+		request := requests[uiCalls]
+		uiCalls++
+		return request, nil
+	}
+
+	var attached []tui.AttachRequest
+	attach := func(request tui.AttachRequest) error {
+		attached = append(attached, request)
+		return nil
+	}
+
+	if err := runSessionManager(runUI, attach); err != nil {
+		t.Fatalf("runSessionManager() error = %v", err)
+	}
+	if uiCalls != 2 {
+		t.Fatalf("TUI ran %d times, want 2", uiCalls)
+	}
+	if len(attached) != 1 || attached[0] != requests[0] {
+		t.Fatalf("attach requests = %+v, want %+v", attached, requests[:1])
+	}
+}


### PR DESCRIPTION
fixes #13 

- **return to zsm after detaching**
- **add e keybind to attach with exec (old behaviour which does not return to zsm after detaching)**

one can try by running from my fork (which contains other fixes and improvements: #3  and #6)

```
nix run github:adrian-gierakowski/zmx-session-manager/fixes-and-flake
```