### PR TITLE
Support zmx 0.5 list output keys

### DIFF
--- a/internal/zmx/session_test.go
+++ b/internal/zmx/session_test.go
@@ -170,6 +170,24 @@ func TestFetchSessionsWithInjectedDeps(t *testing.T) {
 	}
 }
 
+func TestFetchSessionsWithZmx05ListKeys(t *testing.T) {
+	orig := deps
+	defer func() { deps = orig }()
+
+	deps.command = func(name string, arg ...string) *exec.Cmd {
+		script := "printf 'name=demo\\tpid=123\\tclients=2\\tcreated=1778106260\\tstart_dir=/tmp\\n'"
+		return exec.Command("sh", "-c", script)
+	}
+
+	got, err := FetchSessions()
+	if err != nil {
+		t.Fatalf("FetchSessions error: %v", err)
+	}
+	if len(got) != 1 || got[0].Name != "demo" || got[0].PID != "123" || got[0].Clients != 2 || got[0].StartedIn != "/tmp" {
+		t.Fatalf("unexpected sessions parsed: %+v", got)
+	}
+}
+
 func TestCopyToClipboardUsesInjectedDeps(t *testing.T) {
 	orig := deps
 	defer func() { deps = orig }()

--- a/internal/zmx/sessions.go
+++ b/internal/zmx/sessions.go
@@ -48,7 +48,7 @@ func FetchSessions() ([]Session, error) {
 				continue
 			}
 			switch k {
-			case "session_name":
+			case "session_name", "name":
 				s.Name = v
 			case "pid":
 				s.PID = v
@@ -62,7 +62,7 @@ func FetchSessions() ([]Session, error) {
 					}
 					s.Clients = n
 				}
-			case "started_in":
+			case "started_in", "start_dir":
 				s.StartedIn = v
 			case "cmd":
 				s.Cmd = v


### PR DESCRIPTION
## Summary
zsm stopped showing any sessions with the latest versions of zmx. This PR fixes the keys mismatch so sessions are showing in zsm now.

- Accept both old zmx list keys (session_name, started_in) and zmx 0.5 keys (name, start_dir)
- Add a regression test for zmx 0.5-style list output