### PR TITLE
release: preserve Homebrew Cask migration

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -23,12 +23,20 @@ archives:
 
 homebrew_casks:
   - name: zsm
+    binaries: [zsm]
     repository:
       owner: mdsakalu
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
     homepage: "https://github.com/mdsakalu/zmx-session-manager"
     description: "TUI session manager for zmx"
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr",
+                           args: ["-dr", "com.apple.quarantine", "#{staged_path}/zsm"]
+          end
 
 changelog:
   sort: asc


### PR DESCRIPTION
## Summary

- explicitly install the zsm binary from generated Homebrew Casks
- add a macOS postflight hook that removes quarantine from the staged unsigned CLI binary
- keep future GoReleaser runs aligned with the Formula-to-Cask migration merged in mdsakalu/homebrew-tap#1

## Validation

- go test -race ./...
- go vet ./...
- go build ./...
- gofmt -l .
- actionlint
- GoReleaser v2.17.1 check
- GoReleaser snapshot rendered dist/homebrew/Casks/zsm.rb with binary and postflight stanzas
- independent Standards and Spec reviews: clean

No tag or release was created.